### PR TITLE
mapclassify 2.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.4.3" %}
+{% set version = "2.5.0" %}
 
 package:
   name: mapclassify
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/m/mapclassify/mapclassify-{{ version }}.tar.gz
-  sha256: 51b81e1f1ee7f64a4ca1e9f61f01216c364a3f086a48b1be38eb057199cb19bf
+  sha256: 5eb1f782155b5a90ec93c1dc52b300a2fad33117dcf08b7c858ed96da2a7baa0
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,3 +1,4 @@
+{% set name = 'mapclassify' %}
 {% set version = "2.5.0" %}
 
 package:
@@ -10,17 +11,19 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  # Seems like the package is compatible with py>=38,
+  # see https://github.com/pysal/mapclassify/tree/main/ci
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
     - networkx
     - numpy >=1.3
     - pandas >=1.0
@@ -42,6 +45,11 @@ about:
   license_family: BSD
   license_file: LICENSE.txt
   summary: Classification schemes for choropleth maps
+  description: |
+    mapclassify implements a family of classification schemes for choropleth maps. 
+    Its focus is on the determination of the number of classes, and the assignment of observations to those classes. 
+    It is intended for use with upstream mapping and geovisualization packages (see geopandas and geoplot) 
+    that handle the rendering of the maps.
   dev_url: https://github.com/pysal/mapclassify
   doc_url: https://pysal.org/mapclassify/tutorial.html
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,11 +2,11 @@
 {% set version = "2.5.0" %}
 
 package:
-  name: mapclassify
+  name: {{ name|lower }}}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/m/mapclassify/mapclassify-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/m/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 5eb1f782155b5a90ec93c1dc52b300a2fad33117dcf08b7c858ed96da2a7baa0
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "2.5.0" %}
 
 package:
-  name: {{ name|lower }}}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:


### PR DESCRIPTION
**Jira ticket:** [PKG-1049](https://anaconda.atlassian.net/browse/PKG-1049)

**The upstream data:**
Github releases:  https://github.com/pysal/mapclassify/releases
[Diff between the latest and previous upstream releases](https://github.com/pysal/mapclassify/compare/v2.4.3...v2.5.0)
Requirements:
 * setup.py:  https://github.com/pysal/mapclassify/blob/v2.5.0/setup.py
 * https://github.com/pysal/mapclassify/blob/v2.5.0/requirements.txt

**_Actions:_**

1. Add more jinja2 templates
2. Remove `noarch python`
3. Skip `py<38`, see https://github.com/pysal/mapclassify/tree/main/ci
4. Add `--no-deps` to `script`
5. Fix `python` in `host` and `run`
6. Add `description`

**_Notes:_**
 * `geopandas` depends on `mapclassify`

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda_affiliated_deps | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.5.0
 * Release on PyPi:
    * version: 2.5.0
    * date: 2023-01-14T15:50:51
* [PyPi history](https://pypi.org/project/mapclassify/#history)
 * Popularity: 
    * 3 months downloads: 42922.0
    * All time:  1386348 downloads -  mapclassify  2.5.0  Classification schemes for choropleth maps  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/pysal/mapclassify/tree/v2.5.0 exists
8. - [x] Check the pinnings
10. - [x] Additional research
    https://github.com/pysal/mapclassify/issues
13. - [x] Verify that the `build_number` is correct
14. - [x] has `setuptools`
15. - [x] has `wheel`
16. - [x] `pip` in test
17. - [x] Verify the test section
18. - [x] Verify if the package is `architecture specific`
19. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
20.  - [x] license_file: LICENSE.txt is present

21. - [x] license_family BSD is present
22. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check dependency issues:**

<details>
../aggregate/mapclassify-feedstock/recipe/meta.yaml
Dependencies: ['pip', 'networkx', 'python >=3.6', 'scikit-learn', 'pandas >=1.0', 'wheel', 'setuptools', 'scipy >=1.0', 'numpy >=1.3']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libgcc-ng-11.2.0-h1234567_0


linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 18**






**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/mapclassify-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/mapclassify-feedstock/tree/2.5.0)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/mapclassify)
* [Diff between upstream and feature branch](https://github.com/conda-forge/mapclassify-feedstock/compare/main...AnacondaRecipes:2.5.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/mapclassify-feedstock/compare/master...AnacondaRecipes:2.5.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/mapclassify-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.5.0 git@github.com:AnacondaRecipes/mapclassify-feedstock.git
```
