### PR TITLE
mapclassify 2.10.0 - rebuild py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - patches/0000_relax_test_diff_tolerance.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<311]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
@@ -43,6 +43,13 @@ requirements:
 {% set skip_tests = skip_tests + " --deselect=mapclassify/tests/test_legendgram.py::TestLegendgram::test_legendgram_map[png]" %}
 {% set skip_tests = skip_tests + " --deselect=mapclassify/tests/test_legendgram.py::TestLegendgram::test_legendgram_most_recent_cmap[png]" %}
 
+# PY314 Rebuild disable geopandas tests for rebuild only (TODO: remove this once geopandas py314 available)
+{% set ignore_tests_files = " --ignore=mapclassify/tests/test_classify.py" %}
+{% set ignore_tests_files = ignore_tests_files + " --ignore=mapclassify/tests/test_greedy.py" %}
+{% set ignore_tests_files = ignore_tests_files + " --ignore=mapclassify/tests/test_legendgram.py" %}
+{% set ignore_tests_files = ignore_tests_files + " --ignore=mapclassify/tests/test_rgba.py" %}
+{% set ignore_tests_files = ignore_tests_files + " --ignore=mapclassify/tests/test_value_by_alpha.py" %}
+
 test:
   imports:
     - mapclassify
@@ -56,14 +63,14 @@ test:
     - pytest-xdist
     # geopandas earlier than 0.10.0 use ops.cascaded_union from shapely which was removed in 2.0.0.
     # TODO: Update geopandas pinning to >=1.1.0 once available and get rid of the compare diff tolerance relaxation patch
-    - geopandas >=0.10.0
+    # - geopandas >=0.10.0  #TODO: enable once geopandas py314 available
     - libpysal
     - matplotlib-base
     - shapely
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -vv {{ skip_tests }} mapclassify/tests
+    - pytest -ra -vv {{ skip_tests }} {{ ignore_tests_files }} mapclassify/tests
 
 
 about:


### PR DESCRIPTION
mapclassify 2.10.0  - rebuild py314

**Destination channel:** Defaults

### Links

- [PKG-12465]
- dev_url:        https://github.com/pysal/mapclassify/tree/v2.10.0
- conda_forge:    https://github.com/conda-forge/mapclassify-feedstock
- pypi:           https://pypi.org/project/mapclassify/2.10.0
- pypi inspector: https://inspector.pypi.io/project/mapclassify/2.10.0

### Explanation of changes:

- rebuild py314


[PKG-12465]: https://anaconda.atlassian.net/browse/PKG-12465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ